### PR TITLE
RSpec 2 support

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUNDLED_COMMANDS="cucumber rackup rails rake ruby shotgun spec"
+BUNDLED_COMMANDS="cucumber rackup rails rake ruby shotgun spec rspec"
 
 ## Functions
 


### PR DESCRIPTION
I've added the rspec executable as RSpec 2 uses this (and for Rails 3 + RSpec you gotta use RSpec 2).
