### PR TITLE
Capistrano Executables

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BUNDLED_COMMANDS="${BUNDLED_COMMANDS:-cucumber heroku rackup rails rake rspec ruby shotgun spec spork}"
+BUNDLED_COMMANDS="${BUNDLED_COMMANDS:-cucumber heroku rackup rails rake rspec ruby shotgun spec spork capify cap}"
 
 ## Functions
 


### PR DESCRIPTION
Add the ruby executable wrappers for Capsitrano 2.x to the bundle commands list
