### PR TITLE
Fix for bundler commands with spaces

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -29,9 +29,9 @@ within-bundled-project()
 run-with-bundler()
 {
     if bundler-installed && within-bundled-project; then
-        bundle exec $@
+        bundle exec "$@"
     else
-        $@
+        "$@"
     fi
 }
 


### PR DESCRIPTION
Quoted the arglist variable to fix errors from commands with spaces, per http://tldp.org/LDP/abs/html/internalvariables.html#ARGLIST
    which states: "Of course, "$@" should be quoted." Also reference bug thread: https://github.com/gma/bundler-exec/issues/16
