### PR TITLE
Remove 'rails' command

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -47,7 +47,6 @@ heroku
 html2haml
 jasmine
 rackup
-rails
 rake
 rake2thor
 rspec


### PR DESCRIPTION
It should not be run using `bundle exec`:
- http://blog.wyeworks.com/2011/12/27/bundle-exec-rails-executes-bundler-setup-3-times
- http://yehudakatz.com/2011/05/30/gem-versioning-and-bundler-doing-it-right/
