### PR TITLE
Inclusion of librarian-chef to list of bundled commands

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -42,6 +42,7 @@ haml
 heroku
 html2haml
 jasmine
+librarian-chef
 rackup
 rake
 rake2thor


### PR DESCRIPTION
Hi there @gma,

First of all thanks for your work on `bundler-exec`. Would you please consider adding `librarian-chef` to the list of bundled commands?

Librarian-Chef is a tool that helps you manage the cookbooks that
your chef-repo depends on. More information can be found at the
repo: https://github.com/applicationsonline/librarian

Sincerely,

Artur
