### PR TITLE
Add common Chef and Chef testing tools

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -33,6 +33,7 @@ run-with-bundler()
 ## Main program
 
 BUNDLED_COMMANDS="${BUNDLED_COMMANDS:-
+berks
 cap
 capify
 chefspec
@@ -46,9 +47,11 @@ foreman
 guard
 haml
 html2haml
+irb
 jasmine
 kitchen
 knife
+pry
 rackup
 rake
 rake2thor


### PR DESCRIPTION
Many of the tools used in Chef are installed per cookbook, using bundler.

This adds the most frequently used commands to the array.
