### PR TITLE
Remove berks from bundler exec

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -33,7 +33,6 @@ run-with-bundler()
 ## Main program
 
 BUNDLED_COMMANDS="${BUNDLED_COMMANDS:-
-berks
 cap
 capify
 chefspec


### PR DESCRIPTION
Since berkshelf should be installed with the chef development kit (since version 3.0), it should not be executed with bundler anymore.