### PR TITLE
Adding support for ZSH

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -75,8 +75,23 @@ unicorn_rails
 wagon
 }"
 
-for CMD in $BUNDLED_COMMANDS; do
-    if [[ $CMD != "bundle" && $CMD != "gem" ]]; then
-        alias $CMD="run-with-bundler $CMD"
+__bundler_exec_set_aliases() {
+    local CMD
+
+    if [ "$ZSH_VERSION" ]; then
+        # zsh shell
+        # it doesn't iterate on strings the same as Bourne shells by default
+        # we need to set an option for that, and to avoid clobbering the whole
+        # environment, we sandbox that inside this function
+        setopt localoptions shwordsplit
     fi
-done
+
+    for CMD in $BUNDLED_COMMANDS; do
+        if [[ $CMD != "bundle" && $CMD != "gem" ]]; then
+            alias $CMD="run-with-bundler $CMD"
+        fi
+    done
+}
+
+__bundler_exec_set_aliases
+unset -f __bundler_exec_set_aliases


### PR DESCRIPTION
The only incompatibility being the way ZSH handles enumerating strings.

To keep backward-compatibility, instead of changing the type of $BUNDLED_COMMANDS
to an array, we wrap the alias-setting part in a temporary function, and set the
`shwordsplit` ZSH option if inside a ZSH shell; then we get rid of that function
to avoid polluting the global environment.

Tested to work with both bash and zsh.