### PR TITLE
add rails into BUNDLED_COMMANDS

### DIFF
--- a/bundler-exec.sh
+++ b/bundler-exec.sh
@@ -68,6 +68,7 @@ knife
 middleman
 pry
 rackup
+rails
 rake
 rake2thor
 rspec


### PR DESCRIPTION
I'd like to execute `rails` command too without `bundle exec`